### PR TITLE
RHCLOUD-41846 - Enable single threaded unary streams when asyncio is not used

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kessel-sdk"
-version = "1.2.0"
+version = "1.2.1"
 description = "Client SDK for Kessel."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/kessel/inventory/__init__.py
+++ b/src/kessel/inventory/__init__.py
@@ -12,7 +12,7 @@ from grpc.aio import (
     insecure_channel as insecure_channel_async,
     secure_channel as secure_channel_async,
 )
-from grpc.experimental import insecure_channel_credentials
+from grpc.experimental import insecure_channel_credentials, ChannelOptions
 from kessel.grpc import oauth2_call_credentials
 
 from src.kessel.auth import OAuth2ClientCredentials
@@ -58,10 +58,13 @@ class ClientBuilder:
     def build(self):
         credentials = self._build_credentials()
 
+        # Enable single-threaded unary streams
+        channel_options = [(ChannelOptions.SingleThreadedUnaryStream, 1)]
+
         if self._channel_credentials is insecure_channel_credentials():
-            channel = insecure_channel(self._target)
+            channel = insecure_channel(self._target, options=channel_options)
         else:
-            channel = secure_channel(self._target, credentials=credentials)
+            channel = secure_channel(self._target, credentials=credentials, options=channel_options)
 
         return self._stub_class(channel), channel
 

--- a/src/kessel/inventory/v1beta2/report_resource_request_pb2.py
+++ b/src/kessel/inventory/v1beta2/report_resource_request_pb2.py
@@ -27,7 +27,7 @@ from kessel.inventory.v1beta2 import write_visibility_pb2 as kessel_dot_inventor
 from buf.validate import validate_pb2 as buf_dot_validate_dot_validate__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n6kessel/inventory/v1beta2/report_resource_request.proto\x12\x18kessel.inventory.v1beta2\x1a\x37kessel/inventory/v1beta2/resource_representations.proto\x1a/kessel/inventory/v1beta2/write_visibility.proto\x1a\x1b\x62uf/validate/validate.proto\"\xbf\x03\n\x15ReportResourceRequest\x12&\n\x0cinventory_id\x18\x01 \x01(\tH\x00R\x0binventoryId\x88\x01\x01\x12-\n\x04type\x18\x02 \x01(\tB\x19\xbaH\x16r\x14\x10\x01\x32\x10^[A-Za-z0-9_-]+$R\x04type\x12>\n\rreporter_type\x18\x03 \x01(\tB\x19\xbaH\x16r\x14\x10\x01\x32\x10^[A-Za-z0-9_-]+$R\x0creporterType\x12\x39\n\x14reporter_instance_id\x18\x04 \x01(\tB\x07\xbaH\x04r\x02\x10\x01R\x12reporterInstanceId\x12\x63\n\x0frepresentations\x18\x05 \x01(\x0b\x32\x31.kessel.inventory.v1beta2.ResourceRepresentationsB\x06\xbaH\x03\xc8\x01\x01R\x0frepresentations\x12^\n\x10write_visibility\x18\x06 \x01(\x0e\x32).kessel.inventory.v1beta2.WriteVisibilityB\x08\xbaH\x05\x82\x01\x02\x10\x01R\x0fwriteVisibilityB\x0f\n\r_inventory_idBr\n(org.project_kessel.api.inventory.v1beta2P\x01ZDgithub.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n6kessel/inventory/v1beta2/report_resource_request.proto\x12\x18kessel.inventory.v1beta2\x1a\x37kessel/inventory/v1beta2/resource_representations.proto\x1a/kessel/inventory/v1beta2/write_visibility.proto\x1a\x1b\x62uf/validate/validate.proto\"\xd8\x03\n\x15ReportResourceRequest\x12&\n\x0cinventory_id\x18\x01 \x01(\tH\x00R\x0binventoryId\x88\x01\x01\x12-\n\x04type\x18\x02 \x01(\tB\x19\xbaH\x16r\x14\x10\x01\x32\x10^[A-Za-z0-9_-]+$R\x04type\x12>\n\rreporter_type\x18\x03 \x01(\tB\x19\xbaH\x16r\x14\x10\x01\x32\x10^[A-Za-z0-9_-]+$R\x0creporterType\x12\x39\n\x14reporter_instance_id\x18\x04 \x01(\tB\x07\xbaH\x04r\x02\x10\x01R\x12reporterInstanceId\x12\x63\n\x0frepresentations\x18\x05 \x01(\x0b\x32\x31.kessel.inventory.v1beta2.ResourceRepresentationsB\x06\xbaH\x03\xc8\x01\x01R\x0frepresentations\x12^\n\x10write_visibility\x18\x06 \x01(\x0e\x32).kessel.inventory.v1beta2.WriteVisibilityB\x08\xbaH\x05\x82\x01\x02\x10\x01R\x0fwriteVisibility\x12\x17\n\x07use_new\x18\x07 \x01(\x08R\x06useNewB\x0f\n\r_inventory_idBr\n(org.project_kessel.api.inventory.v1beta2P\x01ZDgithub.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -46,5 +46,5 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_REPORTRESOURCEREQUEST'].fields_by_name['write_visibility']._loaded_options = None
   _globals['_REPORTRESOURCEREQUEST'].fields_by_name['write_visibility']._serialized_options = b'\272H\005\202\001\002\020\001'
   _globals['_REPORTRESOURCEREQUEST']._serialized_start=220
-  _globals['_REPORTRESOURCEREQUEST']._serialized_end=667
+  _globals['_REPORTRESOURCEREQUEST']._serialized_end=692
 # @@protoc_insertion_point(module_scope)

--- a/src/kessel/inventory/v1beta2/report_resource_request_pb2.pyi
+++ b/src/kessel/inventory/v1beta2/report_resource_request_pb2.pyi
@@ -9,17 +9,19 @@ from typing import ClassVar as _ClassVar, Optional as _Optional, Union as _Union
 DESCRIPTOR: _descriptor.FileDescriptor
 
 class ReportResourceRequest(_message.Message):
-    __slots__ = ("inventory_id", "type", "reporter_type", "reporter_instance_id", "representations", "write_visibility")
+    __slots__ = ("inventory_id", "type", "reporter_type", "reporter_instance_id", "representations", "write_visibility", "use_new")
     INVENTORY_ID_FIELD_NUMBER: _ClassVar[int]
     TYPE_FIELD_NUMBER: _ClassVar[int]
     REPORTER_TYPE_FIELD_NUMBER: _ClassVar[int]
     REPORTER_INSTANCE_ID_FIELD_NUMBER: _ClassVar[int]
     REPRESENTATIONS_FIELD_NUMBER: _ClassVar[int]
     WRITE_VISIBILITY_FIELD_NUMBER: _ClassVar[int]
+    USE_NEW_FIELD_NUMBER: _ClassVar[int]
     inventory_id: str
     type: str
     reporter_type: str
     reporter_instance_id: str
     representations: _resource_representations_pb2.ResourceRepresentations
     write_visibility: _write_visibility_pb2.WriteVisibility
-    def __init__(self, inventory_id: _Optional[str] = ..., type: _Optional[str] = ..., reporter_type: _Optional[str] = ..., reporter_instance_id: _Optional[str] = ..., representations: _Optional[_Union[_resource_representations_pb2.ResourceRepresentations, _Mapping]] = ..., write_visibility: _Optional[_Union[_write_visibility_pb2.WriteVisibility, str]] = ...) -> None: ...
+    use_new: bool
+    def __init__(self, inventory_id: _Optional[str] = ..., type: _Optional[str] = ..., reporter_type: _Optional[str] = ..., reporter_instance_id: _Optional[str] = ..., representations: _Optional[_Union[_resource_representations_pb2.ResourceRepresentations, _Mapping]] = ..., write_visibility: _Optional[_Union[_write_visibility_pb2.WriteVisibility, str]] = ..., use_new: bool = ...) -> None: ...


### PR DESCRIPTION
Enables the experimental single threaded unary streams channel option in non asyncio setups. https://github.com/grpc/grpc/blob/master/src/python/grpcio/grpc/experimental/__init__.py#L38 


Resolves https://issues.redhat.com/browse/RHCLOUD-41846