### PR TITLE
docs: update docs site url

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://project-kessel.github.io"
+Homepage = "https://project-kessel.github.io/docs/"
 Issues = "https://github.com/project-kessel/kessel-sdk-py"
 
 [project.optional-dependencies]


### PR DESCRIPTION
homepage link visible on PyPi was directing to invalid docs site url, leading to a 404
<img width="1402" height="756" alt="image" src="https://github.com/user-attachments/assets/08811f70-92b4-45b0-9636-4e783fea5cd8" />

Updates link to the proper url.