### PR TITLE
Implement fetch root & default workspace functions

### DIFF
--- a/examples/rbac_fetch_workspace.py
+++ b/examples/rbac_fetch_workspace.py
@@ -1,6 +1,7 @@
 import os
 
 from kessel.auth import fetch_oidc_discovery, OAuth2ClientCredentials
+from kessel.requests import oauth2_auth
 from kessel.rbac.v2 import fetch_default_workspace, fetch_root_workspace
 
 RBAC_BASE_ENDPOINT = os.environ.get("RBAC_BASE_ENDPOINT", "")
@@ -20,9 +21,12 @@ def run():
     try:
         print("Fetching workspaces for org_id 12345")
 
+        # Create auth object
+        auth = oauth2_auth(auth_credentials)
+
         # Fetch default workspace
         default_workspace = fetch_default_workspace(
-            oauth_credentials=auth_credentials,
+            auth=auth,
             rbac_base_endpoint=RBAC_BASE_ENDPOINT,
             org_id="12345",
         )
@@ -30,7 +34,7 @@ def run():
 
         # Fetch root workspace
         root_workspace = fetch_root_workspace(
-            oauth_credentials=auth_credentials,
+            auth=auth,
             rbac_base_endpoint=RBAC_BASE_ENDPOINT,
             org_id="12345",
         )

--- a/examples/rbac_requests_demo.py
+++ b/examples/rbac_requests_demo.py
@@ -1,0 +1,44 @@
+import os
+
+from kessel.auth import fetch_oidc_discovery, OAuth2ClientCredentials
+from kessel.rbac.v2 import fetch_default_workspace, fetch_root_workspace
+
+RBAC_BASE_ENDPOINT = os.environ.get("RBAC_BASE_ENDPOINT", "")
+ISSUER_URL = os.environ.get("AUTH_DISCOVERY_ISSUER_URL", "")
+CLIENT_ID = os.environ.get("AUTH_CLIENT_ID", "")
+CLIENT_SECRET = os.environ.get("AUTH_CLIENT_SECRET", "")
+
+
+def run():
+    discovery = fetch_oidc_discovery(ISSUER_URL)
+    auth_credentials = OAuth2ClientCredentials(
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        token_endpoint=discovery.token_endpoint,
+    )
+
+    try:
+        print("Fetching workspaces for org_id 12345")
+
+        # Fetch default workspace
+        default_workspace = fetch_default_workspace(
+            oauth_credentials=auth_credentials,
+            rbac_base_endpoint=RBAC_BASE_ENDPOINT,
+            org_id="12345",
+        )
+        print(f"Default workspace: {default_workspace.name} (ID: {default_workspace.id})")
+
+        # Fetch root workspace
+        root_workspace = fetch_root_workspace(
+            oauth_credentials=auth_credentials,
+            rbac_base_endpoint=RBAC_BASE_ENDPOINT,
+            org_id="12345",
+        )
+        print(f"Root workspace: {root_workspace.name} (ID: {root_workspace.id})")
+
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    run()

--- a/src/kessel/rbac/v2/__init__.py
+++ b/src/kessel/rbac/v2/__init__.py
@@ -1,7 +1,5 @@
-from typing import Optional
+from typing import Optional, Any
 import requests
-from kessel.auth import OAuth2ClientCredentials
-from kessel.requests import oauth2_auth
 
 
 class Workspace:
@@ -22,7 +20,7 @@ class Workspace:
 
 
 def fetch_root_workspace(
-    oauth_credentials: OAuth2ClientCredentials,
+    auth: Any,
     rbac_base_endpoint: str,
     org_id: str,
     http_client: Optional[requests] = None,
@@ -34,7 +32,7 @@ def fetch_root_workspace(
     GET /api/rbac/v2/workspaces/?type=root
 
     Args:
-        oauth_credentials: OAuth2 client credentials for automatic auth.
+        auth: Authentication object compatible with requests (e.g. oauth2_auth(credentials)).
         rbac_base_endpoint: The RBAC service endpoint URL (stage/prod/ephemeral)
         org_id: Organization ID to use for the request.
         http_client: Optional requests module.
@@ -51,8 +49,6 @@ def fetch_root_workspace(
         "x-rh-rbac-org-id": org_id,
         "Content-Type": "application/json",
     }
-    # Add auth to the request
-    auth = oauth2_auth(oauth_credentials)
 
     response = client.get(url, params={"type": "root"}, headers=headers, auth=auth)
     response.raise_for_status()
@@ -73,7 +69,7 @@ def fetch_root_workspace(
 
 
 def fetch_default_workspace(
-    oauth_credentials: OAuth2ClientCredentials,
+    auth: Any,
     rbac_base_endpoint: str,
     org_id: str,
     http_client: Optional[requests] = None,
@@ -85,7 +81,7 @@ def fetch_default_workspace(
     GET /api/rbac/v2/workspaces/?type=default
 
     Args:
-        oauth_credentials: OAuth2 client credentials for automatic auth.
+        auth: Authentication object compatible with requests (e.g. oauth2_auth(credentials)).
         rbac_base_endpoint: The RBAC service endpoint URL (stage/prod/ephemeral)
         org_id: Organization ID to use for the request.
         http_client: Optional requests module.
@@ -102,9 +98,6 @@ def fetch_default_workspace(
         "x-rh-rbac-org-id": org_id,
         "Content-Type": "application/json",
     }
-
-    # Add auth to the request
-    auth = oauth2_auth(oauth_credentials)
 
     response = client.get(url, params={"type": "default"}, headers=headers, auth=auth)
     response.raise_for_status()

--- a/src/kessel/rbac/v2/__init__.py
+++ b/src/kessel/rbac/v2/__init__.py
@@ -34,13 +34,11 @@ def fetch_root_workspace(
     GET /api/rbac/v2/workspaces/?type=root
 
     Args:
-        oauth_credentials: OAuth2 client credentials for automatic auth. The function will
-                         internally create the appropriate auth adapter for the HTTP library.
+        oauth_credentials: OAuth2 client credentials for automatic auth.
         rbac_base_endpoint: The RBAC service endpoint URL (stage/prod/ephemeral)
         org_id: Organization ID to use for the request.
         http_client: Optional requests module.
                     If not provided, uses the default requests module.
-                    Allows users to inject custom sessions with additional headers or configuration.
 
     Returns:
         A Workspace object representing the root workspace for the organization.
@@ -87,13 +85,11 @@ def fetch_default_workspace(
     GET /api/rbac/v2/workspaces/?type=default
 
     Args:
-        oauth_credentials: OAuth2 client credentials for automatic auth. The function will
-                         internally create the appropriate auth adapter for the HTTP library.
+        oauth_credentials: OAuth2 client credentials for automatic auth.
         rbac_base_endpoint: The RBAC service endpoint URL (stage/prod/ephemeral)
         org_id: Organization ID to use for the request.
         http_client: Optional requests module.
                     If not provided, uses the default requests module.
-                    Allows users to inject custom sessions with additional headers or configuration.
 
     Returns:
         A Workspace object representing the default workspace for the organization.

--- a/src/kessel/rbac/v2/__init__.py
+++ b/src/kessel/rbac/v2/__init__.py
@@ -1,0 +1,128 @@
+from typing import Optional
+import requests
+from kessel.auth import OAuth2ClientCredentials
+from kessel.requests import oauth2_auth
+
+
+class Workspace:
+    def __init__(self, id: str, name: str, type: str, description: str):
+        """
+        Initialize a Workspace instance.
+
+        Args:
+            id: Workspace identifier
+            name: Workspace name
+            type: Workspace type ("root", "default")
+            description: Workspace description
+        """
+        self.id = id
+        self.name = name
+        self.type = type
+        self.description = description
+
+
+def fetch_root_workspace(
+    oauth_credentials: OAuth2ClientCredentials,
+    rbac_base_endpoint: str,
+    org_id: str,
+    http_client: Optional[requests] = None,
+) -> Workspace:
+    """
+    Fetches the root workspace for the specified organization.
+    This function queries RBAC v2 to find the root workspace for the given org_id.
+
+    GET /api/rbac/v2/workspaces/?type=root
+
+    Args:
+        oauth_credentials: OAuth2 client credentials for automatic auth. The function will
+                         internally create the appropriate auth adapter for the HTTP library.
+        rbac_base_endpoint: The RBAC service endpoint URL (stage/prod/ephemeral)
+        org_id: Organization ID to use for the request.
+        http_client: Optional requests module.
+                    If not provided, uses the default requests module.
+                    Allows users to inject custom sessions with additional headers or configuration.
+
+    Returns:
+        A Workspace object representing the root workspace for the organization.
+    """
+    # Use provided http_client or default to requests
+    client = http_client if http_client is not None else requests
+
+    url = f"{rbac_base_endpoint.rstrip('/')}/api/rbac/v2/workspaces/"
+    headers = {
+        "x-rh-rbac-org-id": org_id,
+        "Content-Type": "application/json",
+    }
+    # Add auth to the request
+    auth = oauth2_auth(oauth_credentials)
+
+    response = client.get(url, params={"type": "root"}, headers=headers, auth=auth)
+    response.raise_for_status()
+
+    data = response.json()
+
+    if "data" in data and data["data"]:
+        workspace_data = data["data"][0]
+    else:
+        raise ValueError("No root workspace found in response")
+
+    return Workspace(
+        workspace_data["id"],
+        workspace_data["name"],
+        workspace_data["type"],
+        workspace_data["description"],
+    )
+
+
+def fetch_default_workspace(
+    oauth_credentials: OAuth2ClientCredentials,
+    rbac_base_endpoint: str,
+    org_id: str,
+    http_client: Optional[requests] = None,
+) -> Workspace:
+    """
+    Fetches the default workspace for the specified organization.
+    This function queries RBAC v2 to find the default workspace for the given org_id.
+
+    GET /api/rbac/v2/workspaces/?type=default
+
+    Args:
+        oauth_credentials: OAuth2 client credentials for automatic auth. The function will
+                         internally create the appropriate auth adapter for the HTTP library.
+        rbac_base_endpoint: The RBAC service endpoint URL (stage/prod/ephemeral)
+        org_id: Organization ID to use for the request.
+        http_client: Optional requests module.
+                    If not provided, uses the default requests module.
+                    Allows users to inject custom sessions with additional headers or configuration.
+
+    Returns:
+        A Workspace object representing the default workspace for the organization.
+    """
+    # Use provided http_client or default to requests
+    client = http_client if http_client is not None else requests
+
+    url = f"{rbac_base_endpoint.rstrip('/')}/api/rbac/v2/workspaces/"
+    headers = {
+        "x-rh-rbac-org-id": org_id,
+        "Content-Type": "application/json",
+    }
+
+    # Add auth to the request
+    auth = oauth2_auth(oauth_credentials)
+
+    response = client.get(url, params={"type": "default"}, headers=headers, auth=auth)
+    response.raise_for_status()
+
+    data = response.json()
+
+    if "data" in data and data["data"]:
+        workspace_data = data["data"][0]
+    else:
+        raise ValueError("No default workspace found in response")
+
+    return Workspace(
+        workspace_data["id"],
+        workspace_data["name"],
+        workspace_data["type"],
+        workspace_data["description"],
+    )

--- a/src/kessel/requests/__init__.py
+++ b/src/kessel/requests/__init__.py
@@ -1,0 +1,49 @@
+import requests.auth
+from kessel.auth import OAuth2ClientCredentials
+
+
+class OAuth2Auth(requests.auth.AuthBase):
+    def __init__(self, credentials: OAuth2ClientCredentials):
+        """
+        Args:
+            credentials: The OAuth2ClientCredentials instance to use for auth.
+        """
+        self.credentials = credentials
+
+    def __call__(self, r):
+        """
+        Apply OAuth2 auth to the request.
+
+        This method is called automatically by requests to add auth
+        headers to the request.
+
+        Args:
+            r: The request object to modify.
+
+        Returns:
+            The modified request object with auth headers.
+        """
+        # Get latest token
+        token, _ = self.credentials.get_token()
+
+        # Add Bearer token to the auth header
+        r.headers["Authorization"] = f"Bearer {token}"
+
+        return r
+
+
+def oauth2_auth(credentials: OAuth2ClientCredentials) -> OAuth2Auth:
+    """
+    Create a requests-compatible OAuth2 auth handler.
+
+    This function creates an auth handler that can be used with
+    the requests library, similar to how oauth2_call_credentials creates
+    gRPC call credentials.
+
+    Args:
+        credentials: An OAuth2ClientCredentials instance.
+
+    Returns:
+        OAuth2Auth: An auth handler that can be used with requests.
+    """
+    return OAuth2Auth(credentials)


### PR DESCRIPTION
Implementations of `fetch_root_workspace` and `fetch_default_workspace` functions.

Kept a requests module utility class `OAuth2Auth` to inject the auth into the requests

Related to the spec found [here](https://github.com/project-kessel/docs/pull/52)