### PR TITLE
Remove dependency to protovalidate

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,7 +1,6 @@
 version: v2
 inputs:
   - module: buf.build/project-kessel/inventory-api
-  - module: buf.build/bufbuild/protovalidate:v0.14.1
 plugins:
   - remote: buf.build/protocolbuffers/pyi:v31.1
     out: src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "protovalidate",
     "protobuf~=6.31.1",
     "types-protobuf~=6.30",
     "grpcio",


### PR DESCRIPTION
 - protovalidate does not need to be added as is optional for the SDK.
 - The server is still doing validations
 - Adopters can add this dependency themselves if they would like to run validations on the types, and that is still possible The build code supports that and the validation can be called manually (it was never being called automatically)