### PR TITLE
RHCLOUD-46707 - Implement principal from identity helpers

### DIFF
--- a/examples/console_principal.py
+++ b/examples/console_principal.py
@@ -1,0 +1,43 @@
+import json
+from base64 import b64encode
+
+from kessel.console import principal_from_rh_identity, principal_from_rh_identity_header
+
+
+def run():
+    # --- From a parsed User identity dict ---
+    user_identity = {
+        "type": "User",
+        "org_id": "12345",
+        "user": {"user_id": "7393748", "username": "jdoe"},
+    }
+    subject = principal_from_rh_identity(user_identity)
+    print(f"User principal:            {subject.resource.resource_id}")
+
+    # --- From a parsed ServiceAccount identity dict ---
+    sa_identity = {
+        "type": "ServiceAccount",
+        "org_id": "456",
+        "service_account": {
+            "client_id": "b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+            "username": "service-account-b69eaf9e",
+        },
+    }
+    subject = principal_from_rh_identity(sa_identity)
+    print(f"ServiceAccount principal:  {subject.resource.resource_id}")
+
+    # --- From a raw base64-encoded x-rh-identity header ---
+    header_payload = {
+        "identity": {
+            "type": "User",
+            "org_id": "12345",
+            "user": {"user_id": "7393748", "username": "jdoe"},
+        }
+    }
+    header = b64encode(json.dumps(header_payload).encode()).decode("ascii")
+    subject = principal_from_rh_identity_header(header)
+    print(f"From header principal:     {subject.resource.resource_id}")
+
+
+if __name__ == "__main__":
+    run()

--- a/src/kessel/console/__init__.py
+++ b/src/kessel/console/__init__.py
@@ -1,0 +1,96 @@
+import json
+from base64 import b64decode
+
+from kessel.inventory.v1beta2.subject_reference_pb2 import SubjectReference
+from kessel.rbac.v2 import principal_subject
+
+_IDENTITY_TYPE_FIELDS = {
+    "User": "user",
+    "ServiceAccount": "service_account",
+}
+
+_USER_ID_KEYS = {
+    "User": ("user_id",),
+    "ServiceAccount": ("user_id", "client_id"),
+}
+
+
+def _extract_user_id(identity: dict) -> str:
+    """Extract the user identifier from a parsed x-rh-identity dict.
+
+    Args:
+        identity: The inner identity dict (``{"type": "User", "user": {...}, ...}``).
+
+    Returns:
+        The resolved user identifier string.
+
+    Raises:
+        ValueError: If the identity type is unsupported or no user ID can be resolved.
+    """
+    if not isinstance(identity, dict):
+        raise ValueError("identity must be a dict")
+
+    identity_type = identity.get("type")
+    field = _IDENTITY_TYPE_FIELDS.get(identity_type)
+    if field is None:
+        supported = ", ".join(sorted(_IDENTITY_TYPE_FIELDS))
+        raise ValueError(f"Unsupported identity type: {identity_type!r} (supported: {supported})")
+
+    details = identity.get(field)
+    if not isinstance(details, dict):
+        raise ValueError(f"Identity type {identity_type!r} is missing the {field!r} field")
+
+    for key in _USER_ID_KEYS[identity_type]:
+        value = details.get(key)
+        if value:
+            return value
+
+    tried = ", ".join(_USER_ID_KEYS[identity_type])
+    raise ValueError(
+        f"Unable to resolve user ID from {identity_type} identity " f"(tried: {tried})"
+    )
+
+
+def principal_from_rh_identity(identity: dict, domain: str = "redhat") -> SubjectReference:
+    """Build a principal ``SubjectReference`` from a parsed ``x-rh-identity`` dict.
+
+    Args:
+        identity: The inner identity dict from the ``x-rh-identity`` header
+                  (e.g. ``{"type": "User", "org_id": "...", "user": {...}}``).
+        domain: The domain or organization the user belongs to.
+                Defaults to ``"redhat"``.
+
+    Returns:
+        A ``SubjectReference`` for the resolved principal.
+
+    Raises:
+        ValueError: If the user ID cannot be resolved from the identity.
+    """
+    user_id = _extract_user_id(identity)
+    return principal_subject(user_id, domain)
+
+
+def principal_from_rh_identity_header(header: str, domain: str = "redhat") -> SubjectReference:
+    """Build a principal ``SubjectReference`` from a raw ``x-rh-identity`` header.
+
+    Args:
+        header: The base64-encoded ``x-rh-identity`` header value.
+        domain: The domain or organization the user belongs to.
+                Defaults to ``"redhat"``.
+
+    Returns:
+        A ``SubjectReference`` for the resolved principal.
+
+    Raises:
+        ValueError: If the header is malformed or the user ID cannot be resolved.
+    """
+    try:
+        decoded = json.loads(b64decode(header))
+    except Exception as exc:
+        raise ValueError(f"Failed to decode identity header: {exc}") from exc
+
+    if not isinstance(decoded, dict):
+        raise ValueError("Identity header did not decode to a JSON object")
+
+    identity = decoded.get("identity", decoded)
+    return principal_from_rh_identity(identity, domain)

--- a/src/kessel/console/__init__.py
+++ b/src/kessel/console/__init__.py
@@ -92,5 +92,9 @@ def principal_from_rh_identity_header(header: str, domain: str = "redhat") -> Su
     if not isinstance(decoded, dict):
         raise ValueError("Identity header did not decode to a JSON object")
 
-    identity = decoded.get("identity", decoded)
+    try:
+        identity = decoded["identity"]
+    except KeyError:
+        raise ValueError("Identity header is missing the 'identity' envelope key")
+
     return principal_from_rh_identity(identity, domain)

--- a/src/kessel/console/__init__.py
+++ b/src/kessel/console/__init__.py
@@ -9,11 +9,6 @@ _IDENTITY_TYPE_FIELDS = {
     "ServiceAccount": "service_account",
 }
 
-_USER_ID_KEYS = {
-    "User": ("user_id",),
-    "ServiceAccount": ("user_id", "client_id"),
-}
-
 
 def _extract_user_id(identity: dict) -> str:
     """Extract the user identifier from a parsed x-rh-identity dict.
@@ -40,15 +35,13 @@ def _extract_user_id(identity: dict) -> str:
     if not isinstance(details, dict):
         raise ValueError(f"Identity type {identity_type!r} is missing the {field!r} field")
 
-    for key in _USER_ID_KEYS[identity_type]:
-        value = details.get(key)
-        if value:
-            return value
+    user_id = details.get("user_id")
+    if not user_id:
+        raise ValueError(
+            f"Unable to resolve user ID from {identity_type} identity " f"(tried: user_id)"
+        )
 
-    tried = ", ".join(_USER_ID_KEYS[identity_type])
-    raise ValueError(
-        f"Unable to resolve user ID from {identity_type} identity " f"(tried: {tried})"
-    )
+    return user_id
 
 
 def principal_from_rh_identity(identity: dict, domain: str = "redhat") -> SubjectReference:

--- a/src/kessel/console/__init__.py
+++ b/src/kessel/console/__init__.py
@@ -94,7 +94,7 @@ def principal_from_rh_identity_header(header: str, domain: str = "redhat") -> Su
 
     try:
         identity = decoded["identity"]
-    except KeyError:
-        raise ValueError("Identity header is missing the 'identity' envelope key")
+    except KeyError as exc:
+        raise ValueError("Identity header is missing the 'identity' envelope key") from exc
 
     return principal_from_rh_identity(identity, domain)

--- a/src/kessel/rbac/v2/__init__.py
+++ b/src/kessel/rbac/v2/__init__.py
@@ -1,5 +1,3 @@
-import json
-from base64 import b64decode
 from typing import Optional, AsyncIterator, Iterable
 from requests.auth import AuthBase
 import requests
@@ -243,93 +241,6 @@ def subject(resource_ref: ResourceReference, relation: Optional[str] = None) -> 
         return SubjectReference(resource=resource_ref, relation=relation)
     else:
         return SubjectReference(resource=resource_ref)
-
-
-_IDENTITY_TYPE_FIELDS = {
-    "User": "user",
-    "ServiceAccount": "service_account",
-}
-
-_USER_ID_KEYS = {
-    "User": ("user_id",),
-    "ServiceAccount": ("user_id", "client_id"),
-}
-
-
-def _extract_user_id(identity: dict) -> str:
-    """Extract the user identifier from a parsed x-rh-identity dict.
-
-    Args:
-        identity: The inner identity dict (``{"type": "User", "user": {...}, ...}``).
-
-    Returns:
-        The resolved user identifier string.
-
-    Raises:
-        ValueError: If the identity type is unsupported or no user ID can be resolved.
-    """
-    identity_type = identity.get("type")
-    field = _IDENTITY_TYPE_FIELDS.get(identity_type)
-    if field is None:
-        supported = ", ".join(sorted(_IDENTITY_TYPE_FIELDS))
-        raise ValueError(f"Unsupported identity type: {identity_type!r} (supported: {supported})")
-
-    details = identity.get(field)
-    if not isinstance(details, dict):
-        raise ValueError(f"Identity type {identity_type!r} is missing the {field!r} field")
-
-    for key in _USER_ID_KEYS[identity_type]:
-        value = details.get(key)
-        if value:
-            return value
-
-    tried = ", ".join(_USER_ID_KEYS[identity_type])
-    raise ValueError(
-        f"Unable to resolve user ID from {identity_type} identity " f"(tried: {tried})"
-    )
-
-
-def principal_from_identity(identity: dict, domain: str = "redhat") -> SubjectReference:
-    """Build a principal ``SubjectReference`` from a parsed identity dict.
-
-    Args:
-        identity: The inner identity dict from the ``x-rh-identity`` header
-                  (e.g. ``{"type": "User", "org_id": "...", "user": {...}}``).
-        domain: The domain or organization the user belongs to. Defaults to `"redhat"`.
-
-    Returns:
-        A ``SubjectReference`` for the resolved principal.
-
-    Raises:
-        ValueError: If the user ID cannot be resolved from the identity.
-    """
-    user_id = _extract_user_id(identity)
-    return principal_subject(user_id, domain)
-
-
-def principal_from_identity_header(header: str, domain: str = "redhat") -> SubjectReference:
-    """Build a principal ``SubjectReference`` from a raw ``x-rh-identity`` header.
-
-    Args:
-        header: The base64-encoded ``x-rh-identity`` header value.
-        domain: The domain or organization the user belongs to. Defaults to `"redhat"`.
-
-    Returns:
-        A ``SubjectReference`` for the resolved principal.
-
-    Raises:
-        ValueError: If the header is malformed or the user ID cannot be resolved.
-    """
-    try:
-        decoded = json.loads(b64decode(header))
-    except Exception as exc:
-        raise ValueError(f"Failed to decode identity header: {exc}") from exc
-
-    if not isinstance(decoded, dict):
-        raise ValueError("Identity header did not decode to a JSON object")
-
-    identity = decoded.get("identity", decoded)
-    return principal_from_identity(identity, domain)
 
 
 def list_workspaces(

--- a/src/kessel/rbac/v2/__init__.py
+++ b/src/kessel/rbac/v2/__init__.py
@@ -1,3 +1,5 @@
+import json
+from base64 import b64decode
 from typing import Optional, AsyncIterator, Iterable
 from requests.auth import AuthBase
 import requests
@@ -241,6 +243,93 @@ def subject(resource_ref: ResourceReference, relation: Optional[str] = None) -> 
         return SubjectReference(resource=resource_ref, relation=relation)
     else:
         return SubjectReference(resource=resource_ref)
+
+
+_IDENTITY_TYPE_FIELDS = {
+    "User": "user",
+    "ServiceAccount": "service_account",
+}
+
+_USER_ID_KEYS = {
+    "User": ("user_id",),
+    "ServiceAccount": ("user_id", "client_id"),
+}
+
+
+def _extract_user_id(identity: dict) -> str:
+    """Extract the user identifier from a parsed x-rh-identity dict.
+
+    Args:
+        identity: The inner identity dict (``{"type": "User", "user": {...}, ...}``).
+
+    Returns:
+        The resolved user identifier string.
+
+    Raises:
+        ValueError: If the identity type is unsupported or no user ID can be resolved.
+    """
+    identity_type = identity.get("type")
+    field = _IDENTITY_TYPE_FIELDS.get(identity_type)
+    if field is None:
+        supported = ", ".join(sorted(_IDENTITY_TYPE_FIELDS))
+        raise ValueError(f"Unsupported identity type: {identity_type!r} (supported: {supported})")
+
+    details = identity.get(field)
+    if not isinstance(details, dict):
+        raise ValueError(f"Identity type {identity_type!r} is missing the {field!r} field")
+
+    for key in _USER_ID_KEYS[identity_type]:
+        value = details.get(key)
+        if value:
+            return value
+
+    tried = ", ".join(_USER_ID_KEYS[identity_type])
+    raise ValueError(
+        f"Unable to resolve user ID from {identity_type} identity " f"(tried: {tried})"
+    )
+
+
+def principal_from_identity(identity: dict, domain: str = "redhat") -> SubjectReference:
+    """Build a principal ``SubjectReference`` from a parsed identity dict.
+
+    Args:
+        identity: The inner identity dict from the ``x-rh-identity`` header
+                  (e.g. ``{"type": "User", "org_id": "...", "user": {...}}``).
+        domain: The domain or organization the user belongs to. Defaults to `"redhat"`.
+
+    Returns:
+        A ``SubjectReference`` for the resolved principal.
+
+    Raises:
+        ValueError: If the user ID cannot be resolved from the identity.
+    """
+    user_id = _extract_user_id(identity)
+    return principal_subject(user_id, domain)
+
+
+def principal_from_identity_header(header: str, domain: str = "redhat") -> SubjectReference:
+    """Build a principal ``SubjectReference`` from a raw ``x-rh-identity`` header.
+
+    Args:
+        header: The base64-encoded ``x-rh-identity`` header value.
+        domain: The domain or organization the user belongs to. Defaults to `"redhat"`.
+
+    Returns:
+        A ``SubjectReference`` for the resolved principal.
+
+    Raises:
+        ValueError: If the header is malformed or the user ID cannot be resolved.
+    """
+    try:
+        decoded = json.loads(b64decode(header))
+    except Exception as exc:
+        raise ValueError(f"Failed to decode identity header: {exc}") from exc
+
+    if not isinstance(decoded, dict):
+        raise ValueError("Identity header did not decode to a JSON object")
+
+    identity = decoded.get("identity", decoded)
+    return principal_from_identity(identity, domain)
 
 
 def list_workspaces(

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -129,13 +129,13 @@ class TestPrincipalFromRHIdentityHeader:
         assert ref.resource.resource_id == "redhat/7393748"
         assert ref.resource.resource_type == "principal"
 
-    def test_inner_dict_without_envelope(self):
+    def test_missing_identity_envelope(self):
         header = _encode_identity_header({
             "type": "User",
             "user": {"user_id": "42"},
         })
-        ref = principal_from_rh_identity_header(header)
-        assert ref.resource.resource_id == "redhat/42"
+        with pytest.raises(ValueError, match="missing the 'identity' envelope key"):
+            principal_from_rh_identity_header(header)
 
     def test_service_account_header(self):
         header = _encode_identity_header({

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -32,19 +32,21 @@ class TestExtractUserId:
         }
         assert _extract_user_id(identity) == "sa-456"
 
-    def test_service_account_falls_back_to_client_id(self):
+    def test_service_account_missing_user_id(self):
         identity = {
             "type": "ServiceAccount",
             "service_account": {"client_id": "b69eaf9e"},
         }
-        assert _extract_user_id(identity) == "b69eaf9e"
+        with pytest.raises(ValueError, match="Unable to resolve user ID"):
+            _extract_user_id(identity)
 
-    def test_service_account_skips_empty_user_id(self):
+    def test_service_account_empty_user_id(self):
         identity = {
             "type": "ServiceAccount",
             "service_account": {"user_id": "", "client_id": "b69eaf9e"},
         }
-        assert _extract_user_id(identity) == "b69eaf9e"
+        with pytest.raises(ValueError, match="Unable to resolve user ID"):
+            _extract_user_id(identity)
 
     @pytest.mark.parametrize("identity_type", ["System", "X509", "Associate"])
     def test_unsupported_identity_type(self, identity_type):
@@ -96,10 +98,10 @@ class TestPrincipalFromRHIdentity:
         identity = {
             "type": "ServiceAccount",
             "org_id": "456",
-            "service_account": {"client_id": "b69eaf9e", "username": "svc-b69eaf9e"},
+            "service_account": {"user_id": "sa-456", "client_id": "b69eaf9e", "username": "svc-b69eaf9e"},
         }
         ref = principal_from_rh_identity(identity)
-        assert ref.resource.resource_id == "redhat/b69eaf9e"
+        assert ref.resource.resource_id == "redhat/sa-456"
 
     def test_custom_domain(self):
         identity = {"type": "User", "user": {"user_id": "42"}}
@@ -205,10 +207,11 @@ class TestPrincipalFromRHIdentityHeader:
                 "org_id": "456",
                 "type": "ServiceAccount",
                 "service_account": {
+                    "user_id": "sa-b69eaf9e",
                     "client_id": "b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
                     "username": "service-account-b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
                 },
             }
         })
         ref = principal_from_rh_identity_header(header)
-        assert ref.resource.resource_id == "redhat/b69eaf9e-e6a6-4f9e-805e-02987daddfbd"
+        assert ref.resource.resource_id == "redhat/sa-b69eaf9e"

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,214 @@
+import json
+from base64 import b64encode
+
+import pytest
+
+from kessel.console import (
+    _extract_user_id,
+    principal_from_rh_identity,
+    principal_from_rh_identity_header,
+)
+
+
+class TestExtractUserId:
+    def test_user_with_user_id(self):
+        identity = {"type": "User", "user": {"user_id": "7393748", "username": "foobar"}}
+        assert _extract_user_id(identity) == "7393748"
+
+    def test_user_missing_user_id(self):
+        identity = {"type": "User", "user": {"username": "foobar"}}
+        with pytest.raises(ValueError, match="Unable to resolve user ID"):
+            _extract_user_id(identity)
+
+    def test_user_empty_user_id(self):
+        identity = {"type": "User", "user": {"user_id": ""}}
+        with pytest.raises(ValueError, match="Unable to resolve user ID"):
+            _extract_user_id(identity)
+
+    def test_service_account_with_user_id(self):
+        identity = {
+            "type": "ServiceAccount",
+            "service_account": {"user_id": "sa-456", "client_id": "b69eaf9e"},
+        }
+        assert _extract_user_id(identity) == "sa-456"
+
+    def test_service_account_falls_back_to_client_id(self):
+        identity = {
+            "type": "ServiceAccount",
+            "service_account": {"client_id": "b69eaf9e"},
+        }
+        assert _extract_user_id(identity) == "b69eaf9e"
+
+    def test_service_account_skips_empty_user_id(self):
+        identity = {
+            "type": "ServiceAccount",
+            "service_account": {"user_id": "", "client_id": "b69eaf9e"},
+        }
+        assert _extract_user_id(identity) == "b69eaf9e"
+
+    @pytest.mark.parametrize("identity_type", ["System", "X509", "Associate"])
+    def test_unsupported_identity_type(self, identity_type):
+        identity = {"type": identity_type}
+        with pytest.raises(ValueError, match="Unsupported identity type"):
+            _extract_user_id(identity)
+
+    def test_missing_type_field(self):
+        with pytest.raises(ValueError, match="Unsupported identity type"):
+            _extract_user_id({"org_id": "123"})
+
+    def test_missing_user_details(self):
+        identity = {"type": "User"}
+        with pytest.raises(ValueError, match="missing the 'user' field"):
+            _extract_user_id(identity)
+
+    def test_missing_service_account_details(self):
+        identity = {"type": "ServiceAccount"}
+        with pytest.raises(ValueError, match="missing the 'service_account' field"):
+            _extract_user_id(identity)
+
+    def test_user_details_not_a_dict(self):
+        identity = {"type": "User", "user": "not-a-dict"}
+        with pytest.raises(ValueError, match="missing the 'user' field"):
+            _extract_user_id(identity)
+
+    def test_identity_not_a_dict(self):
+        with pytest.raises(ValueError, match="identity must be a dict"):
+            _extract_user_id(None)
+
+    def test_identity_is_a_string(self):
+        with pytest.raises(ValueError, match="identity must be a dict"):
+            _extract_user_id("not-a-dict")
+
+
+class TestPrincipalFromRHIdentity:
+    def test_user_identity(self):
+        identity = {
+            "type": "User",
+            "org_id": "1979710",
+            "user": {"user_id": "7393748", "username": "foobar"},
+        }
+        ref = principal_from_rh_identity(identity)
+        assert ref.resource.resource_type == "principal"
+        assert ref.resource.resource_id == "redhat/7393748"
+        assert ref.resource.reporter.type == "rbac"
+
+    def test_service_account_identity(self):
+        identity = {
+            "type": "ServiceAccount",
+            "org_id": "456",
+            "service_account": {"client_id": "b69eaf9e", "username": "svc-b69eaf9e"},
+        }
+        ref = principal_from_rh_identity(identity)
+        assert ref.resource.resource_id == "redhat/b69eaf9e"
+
+    def test_custom_domain(self):
+        identity = {"type": "User", "user": {"user_id": "42"}}
+        ref = principal_from_rh_identity(identity, domain="custom")
+        assert ref.resource.resource_id == "custom/42"
+
+    def test_propagates_error_for_unsupported_type(self):
+        identity = {"type": "System", "system": {"cn": "abc"}}
+        with pytest.raises(ValueError, match="Unsupported identity type"):
+            principal_from_rh_identity(identity)
+
+
+def _encode_identity_header(payload: dict) -> str:
+    return b64encode(json.dumps(payload).encode()).decode("ascii")
+
+
+class TestPrincipalFromRHIdentityHeader:
+    def test_full_envelope(self):
+        header = _encode_identity_header({
+            "identity": {
+                "type": "User",
+                "org_id": "1979710",
+                "user": {"user_id": "7393748", "username": "foobar"},
+            }
+        })
+        ref = principal_from_rh_identity_header(header)
+        assert ref.resource.resource_id == "redhat/7393748"
+        assert ref.resource.resource_type == "principal"
+
+    def test_inner_dict_without_envelope(self):
+        header = _encode_identity_header({
+            "type": "User",
+            "user": {"user_id": "42"},
+        })
+        ref = principal_from_rh_identity_header(header)
+        assert ref.resource.resource_id == "redhat/42"
+
+    def test_service_account_header(self):
+        header = _encode_identity_header({
+            "identity": {
+                "type": "ServiceAccount",
+                "org_id": "456",
+                "service_account": {"user_id": "sa-789", "client_id": "b69eaf9e"},
+            }
+        })
+        ref = principal_from_rh_identity_header(header)
+        assert ref.resource.resource_id == "redhat/sa-789"
+
+    def test_custom_domain(self):
+        header = _encode_identity_header({
+            "identity": {"type": "User", "user": {"user_id": "1"}},
+        })
+        ref = principal_from_rh_identity_header(header, domain="acme")
+        assert ref.resource.resource_id == "acme/1"
+
+    def test_malformed_base64(self):
+        with pytest.raises(ValueError, match="Failed to decode identity header"):
+            principal_from_rh_identity_header("not-valid-base64!!!")
+
+    def test_invalid_json(self):
+        header = b64encode(b"this is not json").decode("ascii")
+        with pytest.raises(ValueError, match="Failed to decode identity header"):
+            principal_from_rh_identity_header(header)
+
+    def test_non_object_json(self):
+        header = b64encode(b'"just a string"').decode("ascii")
+        with pytest.raises(ValueError, match="did not decode to a JSON object"):
+            principal_from_rh_identity_header(header)
+
+    def test_unsupported_type_in_header(self):
+        header = _encode_identity_header({
+            "identity": {"type": "System", "system": {"cn": "abc", "cert_type": "system"}},
+        })
+        with pytest.raises(ValueError, match="Unsupported identity type"):
+            principal_from_rh_identity_header(header)
+
+    def test_realistic_user_header(self):
+        header = _encode_identity_header({
+            "identity": {
+                "account_number": "540155",
+                "org_id": "1979710",
+                "user": {
+                    "username": "rhn-support-foobar",
+                    "is_internal": True,
+                    "is_org_admin": True,
+                    "first_name": "foo",
+                    "last_name": "bar",
+                    "is_active": True,
+                    "user_id": "7393748",
+                    "email": "example@redhat.com",
+                },
+                "type": "User",
+            }
+        })
+        ref = principal_from_rh_identity_header(header)
+        assert ref.resource.resource_id == "redhat/7393748"
+        assert ref.resource.resource_type == "principal"
+        assert ref.resource.reporter.type == "rbac"
+
+    def test_realistic_service_account_header(self):
+        header = _encode_identity_header({
+            "identity": {
+                "org_id": "456",
+                "type": "ServiceAccount",
+                "service_account": {
+                    "client_id": "b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+                    "username": "service-account-b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+                },
+            }
+        })
+        ref = principal_from_rh_identity_header(header)
+        assert ref.resource.resource_id == "redhat/b69eaf9e-e6a6-4f9e-805e-02987daddfbd"

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -178,6 +178,31 @@ class TestPrincipalFromRHIdentityHeader:
         with pytest.raises(ValueError, match="Unsupported identity type"):
             principal_from_rh_identity_header(header)
 
+    def test_user_header_missing_user_id(self):
+        header = _encode_identity_header({
+            "identity": {
+                "type": "User",
+                "org_id": "1979710",
+                "user": {"username": "foobar"},
+            }
+        })
+        with pytest.raises(ValueError, match="Unable to resolve user ID"):
+            principal_from_rh_identity_header(header)
+
+    def test_service_account_header_missing_user_id(self):
+        header = _encode_identity_header({
+            "identity": {
+                "type": "ServiceAccount",
+                "org_id": "456",
+                "service_account": {
+                    "client_id": "b69eaf9e",
+                    "username": "svc-b69eaf9e",
+                },
+            }
+        })
+        with pytest.raises(ValueError, match="Unable to resolve user ID"):
+            principal_from_rh_identity_header(header)
+
     def test_realistic_user_header(self):
         header = _encode_identity_header({
             "identity": {


### PR DESCRIPTION
Adds `principal_from_rh_identity()` and `principal_from_rh_identity_header()` to new `kessel.console` pkg, enabling consumers to build principal SubjectReferences directly from platform identity dicts or raw x-rh-identity headers.


https://redhat.atlassian.net/browse/RHCLOUD-46707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added identity header processing and utilities to derive principal references for user and service-account identities with configurable domain prefixes.
* **Bug Fixes / Robustness**
  * Improved validation and clearer error reporting for malformed, missing, or unsupported identity payloads.
* **Tests & Examples**
  * Added comprehensive tests and an example script demonstrating principal extraction flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->