### PR TITLE
RHCLOUD-47738: Add locking mechanism for concurrent token refreshes

### DIFF
--- a/src/kessel/auth/auth.py
+++ b/src/kessel/auth/auth.py
@@ -1,4 +1,5 @@
 import datetime
+import threading
 
 import google.auth.credentials
 import google.auth.transport.requests
@@ -96,10 +97,23 @@ class OAuth2ClientCredentials:
 
         self._token = None
         self._expiry = None
+        self._lock = threading.Lock()
+        self._generation = 0
+
+    def _needs_refresh(self) -> bool:
+        current_time = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        return (
+            self._token is None
+            or self._expiry is None
+            or self._expiry <= current_time + datetime.timedelta(seconds=300)
+        )
 
     def get_token(self, force_refresh: bool = False) -> RefreshTokenResponse:
         """
         Get a valid access token, refreshing if necessary or forced.
+
+        Uses double-checked locking to ensure that concurrent callers
+        coalesce into a single SSO token request per refresh cycle.
 
         Args:
             force_refresh: If True, forces token refresh regardless of expiry.
@@ -107,15 +121,20 @@ class OAuth2ClientCredentials:
         Returns:
             RefreshTokenResponse object containing access_token and expires_at.
         """
-        current_time = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        # Snapshot the generation before the lock so we can detect if another
+        # thread refreshed while we were waiting. A changed generation means a
+        # fresh token is already available, letting us skip the SSO call.
+        generation = self._generation
 
-        if (
-            force_refresh
-            or self._token is None
-            or self._expiry is None
-            or self._expiry <= current_time + datetime.timedelta(seconds=300)
-        ):
-            # Refresh the token
+        if not force_refresh and not self._needs_refresh():
+            return RefreshTokenResponse(access_token=self._token, expires_at=self._expiry)
+
+        with self._lock:
+            # Another thread already refreshed while we waited — accept that token
+            if self._generation != generation and not self._needs_refresh():
+                return RefreshTokenResponse(access_token=self._token, expires_at=self._expiry)
+
+            current_time = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
             token_data = self._session.fetch_token(
                 token_url=self._token_endpoint,
                 client_id=self._client_id,
@@ -125,6 +144,7 @@ class OAuth2ClientCredentials:
             self._token = token_data.get("access_token")
             expires_in = token_data.get("expires_in", 0)
             self._expiry = current_time + datetime.timedelta(seconds=expires_in)
+            self._generation += 1
 
         return RefreshTokenResponse(access_token=self._token, expires_at=self._expiry)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,10 @@
-import pytest
 import datetime
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from unittest.mock import Mock, patch
+
+import pytest
 from requests.exceptions import HTTPError
 
 from kessel.auth import (
@@ -416,3 +420,83 @@ def test_token_with_zero_expires_in():
         assert result.expires_at <= datetime.datetime.now(datetime.timezone.utc).replace(
             tzinfo=None
         ) + datetime.timedelta(seconds=1)
+
+
+def test_get_token_concurrent_refresh_calls_sso_once():
+    """Test that concurrent get_token() calls result in exactly one SSO fetch."""
+    credentials = OAuth2ClientCredentials(
+        "test-client", "test-secret", "https://example.com/token"
+    )
+
+    credentials._token = "expiring-token"
+    credentials._expiry = datetime.datetime.now(datetime.timezone.utc).replace(
+        tzinfo=None
+    ) + datetime.timedelta(seconds=60)
+
+    barrier = threading.Barrier(20)
+    mock_token_data = {
+        "access_token": "refreshed-token",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+
+    # Simulate real SSO latency so threads have time to pile up
+    def slow_fetch(*_args, **_kwargs):
+        time.sleep(0.05)
+        return mock_token_data
+
+    original_fetch = Mock(side_effect=slow_fetch)
+
+    with patch.object(credentials._session, "fetch_token", original_fetch):
+
+        def call_get_token():
+            barrier.wait()
+            return credentials.get_token()
+
+        with ThreadPoolExecutor(max_workers=20) as executor:
+            futures = [executor.submit(call_get_token) for _ in range(20)]
+            results = [f.result() for f in as_completed(futures)]
+
+    assert original_fetch.call_count == 1
+    for result in results:
+        assert result.access_token == "refreshed-token"
+
+
+def test_get_token_concurrent_force_refresh_calls_sso_once():
+    """Test that concurrent force_refresh=True calls result in exactly one SSO fetch."""
+    credentials = OAuth2ClientCredentials(
+        "test-client", "test-secret", "https://example.com/token"
+    )
+
+    credentials._token = "expiring-token"
+    credentials._expiry = datetime.datetime.now(datetime.timezone.utc).replace(
+        tzinfo=None
+    ) + datetime.timedelta(seconds=60)
+
+    barrier = threading.Barrier(20)
+    mock_token_data = {
+        "access_token": "force-refreshed-token",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+
+    # Simulate real SSO latency so threads have time to pile up
+    def slow_fetch(*_args, **_kwargs):
+        time.sleep(0.05)
+        return mock_token_data
+
+    original_fetch = Mock(side_effect=slow_fetch)
+
+    with patch.object(credentials._session, "fetch_token", original_fetch):
+
+        def call_get_token():
+            barrier.wait()
+            return credentials.get_token(force_refresh=True)
+
+        with ThreadPoolExecutor(max_workers=20) as executor:
+            futures = [executor.submit(call_get_token) for _ in range(20)]
+            results = [f.result() for f in as_completed(futures)]
+
+    assert original_fetch.call_count == 1
+    for result in results:
+        assert result.access_token == "force-refreshed-token"


### PR DESCRIPTION
- Extracts refresh logic into it's own function
- Introduces thread-safe locking for token refreshes such that many calls do not all attempt to refresh an expired token
  - When the token is valid, callers return it immediately. When it's expired, all concurrent callers queue on a lock so only one hits SSO; the rest pick up the fresh token when they get through.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made credential refresh thread-safe to prevent race conditions when many requests refresh tokens simultaneously, improving reliability under concurrent load.

* **Tests**
  * Added a second multithreaded concurrency test that verifies forced-refresh calls still trigger only one underlying token fetch while all callers receive the refreshed token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->