### PR TITLE
Release v2.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kessel-sdk"
-version = "2.6.0"
+version = "2.6.1"
 description = "Client SDK for Kessel."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Release version 2.6.1 (patch).

Includes changes since v2.6.0 already on `main`:
- Concurrent token refresh locking (`OAuth2ClientCredentials`)
- Expanded protobuf dependency range (`>=6.31.1,<7.36.0`)

## Test plan

- [x] `black` / `flake8` on `src/` and `examples/`
- [x] `pytest`
- [x] `python -m build` produces `kessel_sdk-2.6.1` artifacts


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version bumped to 2.6.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->