### PR TITLE
RHCLOUD-48372 - Add consistency token option to ListWorkspaces helper

### DIFF
--- a/examples/rbac_list_workspaces.py
+++ b/examples/rbac_list_workspaces.py
@@ -7,6 +7,7 @@ from kessel.auth import fetch_oidc_discovery, OAuth2ClientCredentials
 from kessel.inventory.v1beta2 import (
     ClientBuilder,
 )
+from kessel.inventory.v1beta2 import consistency_pb2
 from kessel.rbac.v2 import list_workspaces, list_workspaces_async, principal_subject
 
 
@@ -42,12 +43,24 @@ def run_sync():
             print(f"Listing workspaces (sync) for subject='{SUBJECT_ID}' relation='{RELATION}'")
 
             # Iterate one-by-one (lazy, constant memory)
-            for obj in list_workspaces(stub, subject=subject, relation=RELATION):
+            for obj in list_workspaces(
+                stub,
+                subject=subject,
+                relation=RELATION,
+                consistency=consistency_pb2.Consistency(minimize_latency=True),
+            ):
                 print(f"{obj}")
                 print(f"{obj.pagination.continuation_token}")
 
             # Materialise all workspaces into a list
-            all_workspaces = list(list_workspaces(stub, subject=subject, relation=RELATION))
+            all_workspaces = list(
+                list_workspaces(
+                    stub,
+                    subject=subject,
+                    relation=RELATION,
+                    consistency=consistency_pb2.Consistency(minimize_latency=True),
+                )
+            )
             print(f"Total workspaces (sync): {len(all_workspaces)}")
 
     except grpc.RpcError as e:
@@ -78,13 +91,24 @@ async def run_async():
             print(f"Listing workspaces (async) for subject='{SUBJECT_ID}' relation='{RELATION}'")
 
             # Iterate one-by-one (lazy, constant memory)
-            async for obj in list_workspaces_async(stub, subject=subject, relation=RELATION):
+            async for obj in list_workspaces_async(
+                stub,
+                subject=subject,
+                relation=RELATION,
+                consistency=consistency_pb2.Consistency(minimize_latency=True),
+            ):
                 print(f"{obj}")
                 print(f"{obj.pagination.continuation_token}")
 
             # Materialise all workspaces into a list
             all_workspaces = [
-                r async for r in list_workspaces_async(stub, subject=subject, relation=RELATION)
+                r
+                async for r in list_workspaces_async(
+                    stub,
+                    subject=subject,
+                    relation=RELATION,
+                    consistency=consistency_pb2.Consistency(minimize_latency=True),
+                )
             ]
             print(f"Total workspaces (async): {len(all_workspaces)}")
 

--- a/src/kessel/rbac/v2/__init__.py
+++ b/src/kessel/rbac/v2/__init__.py
@@ -2,6 +2,7 @@ from typing import Optional, AsyncIterator, Iterable
 from requests.auth import AuthBase
 import requests
 
+from kessel.inventory.v1beta2.consistency_pb2 import Consistency
 from kessel.inventory.v1beta2.representation_type_pb2 import RepresentationType
 from kessel.inventory.v1beta2.resource_reference_pb2 import ResourceReference
 from kessel.inventory.v1beta2.subject_reference_pb2 import SubjectReference
@@ -248,6 +249,7 @@ def list_workspaces(
     subject: SubjectReference,
     relation: str,
     continuation_token: Optional[str] = None,
+    consistency: Optional[Consistency] = None,
 ) -> Iterable[StreamedListObjectsResponse]:
     """
     Lists all workspaces that a subject has a specific relation to.
@@ -262,6 +264,7 @@ def list_workspaces(
         subject: The subject to check permissions for.
         relation: The relationship type to check (e.g. "member", "admin", "viewer").
         continuation_token: Optional token to resume listing from a previous page
+        consistency: Optional consistency requirement for the request (e.g. at_least_as_fresh).
 
     Returns:
         An iterator of StreamedListObjectsResponse messages.
@@ -289,6 +292,7 @@ def list_workspaces(
             relation=relation,
             subject=subject,
             pagination=pagination,
+            consistency=consistency,
         )
 
         last_token = None
@@ -308,6 +312,7 @@ async def list_workspaces_async(
     subject: SubjectReference,
     relation: str,
     continuation_token: Optional[str] = None,
+    consistency: Optional[Consistency] = None,
 ) -> AsyncIterator[StreamedListObjectsResponse]:
     """
     Async version of :func:`list_workspaces`.
@@ -323,6 +328,7 @@ async def list_workspaces_async(
         subject: The subject to check permissions for.
         relation: The relationship type to check (e.g. "member", "admin", "viewer").
         continuation_token: Optional token to resume listing from a previous position.
+        consistency: Optional consistency requirement for the request (e.g. at_least_as_fresh).
 
     Returns:
         An async iterator of StreamedListObjectsResponse messages.
@@ -352,6 +358,7 @@ async def list_workspaces_async(
             relation=relation,
             subject=subject,
             pagination=pagination,
+            consistency=consistency,
         )
 
         last_token = None

--- a/tests/test_rbac_v2.py
+++ b/tests/test_rbac_v2.py
@@ -14,6 +14,8 @@ from kessel.rbac.v2 import (
     fetch_root_workspace,
     fetch_default_workspace,
 )
+from kessel.inventory.v1beta2.consistency_pb2 import Consistency
+from kessel.inventory.v1beta2.consistency_token_pb2 import ConsistencyToken
 from kessel.inventory.v1beta2.streamed_list_objects_response_pb2 import StreamedListObjectsResponse
 from kessel.inventory.v1beta2.response_pagination_pb2 import ResponsePagination
 
@@ -196,19 +198,76 @@ class TestListWorkspaces:
             pagination=ResponsePagination(continuation_token="")
         )
         mock_inventory.StreamedListObjects.return_value = iter([response])
-        
+
         subj = principal_subject("user123", "redhat")
-        
+
         responses = list(list_workspaces(mock_inventory, subj, "member", continuation_token=None))
-        
+
         assert len(responses) == 1
-        
-        # Verify the request had no pagination field set 
+
+        # Verify the request had no pagination field set
         call_args = mock_inventory.StreamedListObjects.call_args[0][0]
         if hasattr(call_args, 'HasField'):
             assert not call_args.HasField("pagination")
         else:
             assert call_args.pagination is None
+
+    def test_passes_consistency_to_request(self):
+        """Test that list_workspaces passes consistency token through to the request"""
+        mock_inventory = Mock()
+        response = StreamedListObjectsResponse(
+            pagination=ResponsePagination(continuation_token="")
+        )
+        mock_inventory.StreamedListObjects.return_value = iter([response])
+
+        subj = principal_subject("user123", "redhat")
+        consistency = Consistency(
+            at_least_as_fresh=ConsistencyToken(token="tok-abc")
+        )
+
+        list(list_workspaces(mock_inventory, subj, "member", consistency=consistency))
+
+        call_args = mock_inventory.StreamedListObjects.call_args[0][0]
+        assert call_args.consistency == consistency
+        assert call_args.consistency.at_least_as_fresh.token == "tok-abc"
+
+    def test_no_consistency_by_default(self):
+        """Test that list_workspaces omits consistency when not provided"""
+        mock_inventory = Mock()
+        response = StreamedListObjectsResponse(
+            pagination=ResponsePagination(continuation_token="")
+        )
+        mock_inventory.StreamedListObjects.return_value = iter([response])
+
+        subj = principal_subject("user123", "redhat")
+
+        list(list_workspaces(mock_inventory, subj, "member"))
+
+        call_args = mock_inventory.StreamedListObjects.call_args[0][0]
+        assert not call_args.HasField("consistency")
+
+    def test_consistency_preserved_across_pagination(self):
+        """Test that list_workspaces passes consistency on every paginated request"""
+        mock_inventory = Mock()
+        response1 = StreamedListObjectsResponse(
+            pagination=ResponsePagination(continuation_token="page2")
+        )
+        response2 = StreamedListObjectsResponse(
+            pagination=ResponsePagination(continuation_token="")
+        )
+        mock_inventory.StreamedListObjects.side_effect = [
+            iter([response1]),
+            iter([response2]),
+        ]
+
+        subj = principal_subject("user123", "redhat")
+        consistency = Consistency(at_least_as_fresh=ConsistencyToken(token="tok-xyz"))
+
+        list(list_workspaces(mock_inventory, subj, "viewer", consistency=consistency))
+
+        assert mock_inventory.StreamedListObjects.call_count == 2
+        for call in mock_inventory.StreamedListObjects.call_args_list:
+            assert call[0][0].consistency == consistency
 
 
 class TestListWorkspacesAsync:
@@ -346,25 +405,99 @@ class TestListWorkspacesAsync:
         response = StreamedListObjectsResponse(
             pagination=ResponsePagination(continuation_token="")
         )
-        
+
         async def async_iter():
             yield response
-        
+
         mock_inventory.StreamedListObjects.return_value = async_iter()
-        
+
         subj = principal_subject("user123", "redhat")
-        
+
         responses = []
         async for resp in list_workspaces_async(mock_inventory, subj, "member", continuation_token=None):
             responses.append(resp)
-        
+
         assert len(responses) == 1
-        
+
         call_args = mock_inventory.StreamedListObjects.call_args[0][0]
         if hasattr(call_args, 'HasField'):
             assert not call_args.HasField("pagination")
         else:
             assert call_args.pagination is None
+
+    @pytest.mark.asyncio
+    async def test_passes_consistency_to_request(self):
+        """Test that list_workspaces_async passes consistency token through to the request"""
+        mock_inventory = Mock()
+        response = StreamedListObjectsResponse(
+            pagination=ResponsePagination(continuation_token="")
+        )
+
+        async def async_iter():
+            yield response
+
+        mock_inventory.StreamedListObjects.return_value = async_iter()
+
+        subj = principal_subject("user123", "redhat")
+        consistency = Consistency(at_least_as_fresh=ConsistencyToken(token="tok-abc"))
+
+        responses = []
+        async for resp in list_workspaces_async(mock_inventory, subj, "member", consistency=consistency):
+            responses.append(resp)
+
+        call_args = mock_inventory.StreamedListObjects.call_args[0][0]
+        assert call_args.consistency == consistency
+        assert call_args.consistency.at_least_as_fresh.token == "tok-abc"
+
+    @pytest.mark.asyncio
+    async def test_no_consistency_by_default(self):
+        """Test that list_workspaces_async omits consistency when not provided"""
+        mock_inventory = Mock()
+        response = StreamedListObjectsResponse(
+            pagination=ResponsePagination(continuation_token="")
+        )
+
+        async def async_iter():
+            yield response
+
+        mock_inventory.StreamedListObjects.return_value = async_iter()
+
+        subj = principal_subject("user123", "redhat")
+
+        async for _ in list_workspaces_async(mock_inventory, subj, "member"):
+            pass
+
+        call_args = mock_inventory.StreamedListObjects.call_args[0][0]
+        assert not call_args.HasField("consistency")
+
+    @pytest.mark.asyncio
+    async def test_consistency_preserved_across_pagination(self):
+        """Test that list_workspaces_async passes consistency on every paginated request"""
+        mock_inventory = Mock()
+        response1 = StreamedListObjectsResponse(
+            pagination=ResponsePagination(continuation_token="page2")
+        )
+        response2 = StreamedListObjectsResponse(
+            pagination=ResponsePagination(continuation_token="")
+        )
+
+        async def async_iter1():
+            yield response1
+
+        async def async_iter2():
+            yield response2
+
+        mock_inventory.StreamedListObjects.side_effect = [async_iter1(), async_iter2()]
+
+        subj = principal_subject("user123", "redhat")
+        consistency = Consistency(at_least_as_fresh=ConsistencyToken(token="tok-xyz"))
+
+        async for _ in list_workspaces_async(mock_inventory, subj, "viewer", consistency=consistency):
+            pass
+
+        assert mock_inventory.StreamedListObjects.call_count == 2
+        for call in mock_inventory.StreamedListObjects.call_args_list:
+            assert call[0][0].consistency == consistency
 
 
 class TestFetchDefaultWorkspace:


### PR DESCRIPTION
  - Add optional consistency parameter to `list_workspaces()` and `list_workspaces_async()` in kessel/rbac/v2
  - Pass the parameter through to `StreamedListObjectsRequest` on every page of a paginated call
  - Updates `rbac_list_workspaces.py` example 


https://redhat.atlassian.net/browse/RHCLOUD-48372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional consistency parameter to workspace listing (sync and async) so callers can specify request consistency and have it applied across paginated requests.

* **Tests**
  * Added tests verifying consistency is passed through, omitted by default, and preserved across pagination.

* **Examples**
  * Updated example usage to demonstrate providing a consistency parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->